### PR TITLE
python3 support

### DIFF
--- a/scriptine/__init__.py
+++ b/scriptine/__init__.py
@@ -1,6 +1,6 @@
 from scriptine._path import path
 from scriptine.command import run, cmd
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 __all__ = ['path', 'run', 'cmd', 'autocmds']

--- a/scriptine/command.py
+++ b/scriptine/command.py
@@ -204,7 +204,7 @@ def cmd(function, args=None):
 
 def print_help(namespace, command_suffix):
     group_commands = defaultdict(list)
-    for func_name, func in namespace.iteritems():
+    for func_name, func in namespace.items():
         if func_name.endswith(command_suffix):
             func = namespace[func_name]
             group = getattr(func, 'group', None)
@@ -212,7 +212,10 @@ def print_help(namespace, command_suffix):
             group_commands[group].append((command_name, func.__doc__))
     
     if not group_commands:
-        print >>sys.stderr, 'no commands found in', sys.argv[0]
+        try:
+            print >>sys.stderr, 'no commands found in', sys.argv[0]
+        except TypeError:
+            print('no commands found in', sys.argv[0], file=sys.stderr)
         return
     
     usage = 'usage: %prog command [options]'
@@ -222,21 +225,30 @@ def print_help(namespace, command_suffix):
     default_commands = group_commands.pop(None, None)
     if default_commands:
         print_commands(None, default_commands)
-    for group_name, commands in group_commands.iteritems():
+    for group_name, commands in group_commands.items():
         print_commands(group_name, commands)
 
 def print_commands(group_name, commands):
-    if group_name:
-        print >>sys.stderr, '\n%s commands:' % group_name.title()
-    else:
-        print >>sys.stderr, '\nCommands:'
+    try:
+        if group_name:
+            print >>sys.stderr, '\n%s commands:' % group_name.title()
+        else:
+            print >>sys.stderr, '\nCommands:'
+    except TypeError:
+        if group_name:
+            print('\n%s commands:' % group_name.title(), file=sys.stderr)
+        else:
+            print('\nCommands:', file=sys.stderr)
     cmd_len = max(len(cmd) for cmd, _ in commands)
     for cmd, doc in commands:
         if doc is not None:
             doc = doc.strip().split('\n')[0]
         else:
             doc = ''
-        print >>sys.stderr, ('  %-' + str(cmd_len) + 's  %s') % (cmd, doc)
+        try:
+            print >>sys.stderr, ('  %-' + str(cmd_len) + 's  %s') % (cmd, doc)
+        except TypeError:
+            print(('  %-' + str(cmd_len) + 's  %s') % (cmd, doc), file=sys.stderr)
 
 def parse_rst_params(doc):
     """

--- a/scriptine/misc.py
+++ b/scriptine/misc.py
@@ -3,6 +3,7 @@ import re
 import inspect
 from distutils.core import Command
 from scriptine import log
+from wrapt import decorator
 
 class DistutilsCommand(Command):
     user_options = []
@@ -47,131 +48,6 @@ options = Options()
 options.dry = False
 
 
-# --- begin decorator ---
-##########################     LICENCE     ###############################
-      
-##   Redistributions of source code must retain the above copyright 
-##   notice, this list of conditions and the following disclaimer.
-##   Redistributions in bytecode form must reproduce the above copyright
-##   notice, this list of conditions and the following disclaimer in
-##   the documentation and/or other materials provided with the
-##   distribution. 
-
-##   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-##   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-##   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-##   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-##   HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-##   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-##   BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-##   OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-##   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-##   TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-##   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-##   DAMAGE.
-
-"""
-Decorator module, see http://pypi.python.org/pypi/decorator
-for the documentation.
-"""
-
-# basic functionality
-class FunctionMaker(object):
-    """
-    An object with the ability to create functions with a given signature.
-    It has attributes name, doc, module, signature, defaults, dict and
-    methods update and make.
-    """
-    DEF = re.compile('\s*def\s*([_\w][_\w\d]*)\s*\(')
-    def __init__(self, func=None, name=None, signature=None,
-                 defaults=None, doc=None, module=None, funcdict=None):
-        if func:
-            # func can also be a class or a callable, but not an instance method
-            self.name = func.__name__
-            if self.name == '<lambda>': # small hack for lambda functions
-                self.name = '_lambda_' 
-            self.doc = func.__doc__
-            self.module = func.__module__
-            if inspect.isfunction(func):
-                self.signature = inspect.formatargspec(
-                    formatvalue=lambda val: "", *inspect.getargspec(func))[1:-1]
-                self.defaults = func.func_defaults
-                self.dict = func.__dict__.copy()
-        if name:
-            self.name = name
-        if signature is not None:
-            self.signature = signature
-        if defaults:
-            self.defaults = defaults
-        if doc:
-            self.doc = doc
-        if module:
-            self.module = module
-        if funcdict:
-            self.dict = funcdict
-        # check existence required attributes
-        assert hasattr(self, 'name')
-        if not hasattr(self, 'signature'):
-            raise TypeError('You are decorating a non function: %s' % func)
-
-    def update(self, func, **kw):
-        "Update the signature of func with the data in self"
-        func.__name__ = self.name
-        func.__doc__ = getattr(self, 'doc', None)
-        func.__dict__ = getattr(self, 'dict', {})
-        func.func_defaults = getattr(self, 'defaults', None)
-        callermodule = sys._getframe(3).f_globals.get('__name__', '?')
-        func.__module__ = getattr(self, 'module', callermodule)
-        func.__dict__.update(kw)
- 
-    def make(self, src_templ, evaldict=None, addsource=False, **attrs):
-        "Make a new function from a given template and update the signature"
-        src = src_templ % vars(self) # expand name and signature
-        evaldict = evaldict or {}
-        mo = FunctionMaker.DEF.match(src)
-        if mo is None:
-            raise SyntaxError('not a valid function template\n%s' % src)
-        name = mo.group(1) # extract the function name
-        reserved_names = set([name] + [
-            arg.strip(' *') for arg in self.signature.split(',')])
-        for n, v in evaldict.iteritems():
-            if n in reserved_names:
-                raise NameError('%s is overridden in\n%s' % (n, src))
-        if not src.endswith('\n'): # add a newline just for safety
-            src += '\n'
-        try:
-            code = compile(src, '<string>', 'single')
-            exec code in evaldict
-        except:
-            print >> sys.stderr, 'Error in generated code:'
-            print >> sys.stderr, src
-            raise
-        func = evaldict[name]
-        if addsource:
-            attrs['__source__'] = src
-        self.update(func, **attrs)
-        return func
-
-def decorator(caller, func=None):
-    """
-    decorator(caller) converts a caller function into a decorator;
-    decorator(caller, func) decorates a function using a caller.
-    """
-    if func is None: # returns a decorator
-        fun = FunctionMaker(caller)
-        first_arg = inspect.getargspec(caller)[0][0]
-        src = 'def %s(%s): return _call_(caller, %s)' % (
-            caller.__name__, first_arg, first_arg)
-        return fun.make(src, dict(caller=caller, _call_=decorator),
-                        undecorated=caller)
-    else: # returns a decorated function
-        fun = FunctionMaker(func)
-        src = """def %(name)s(%(signature)s):
-    return _call_(_func_, %(signature)s)"""
-        return fun.make(src, dict(_func_=func, _call_=caller), undecorated=func)
-
-# --- end decorator ---
-
 def dry(message, func, *args, **kw):
     log.info(message)
     
@@ -179,7 +55,7 @@ def dry(message, func, *args, **kw):
         return func(*args, **kw)
 
 @decorator
-def log_call(func, *args, **kw):
+def log_call(func, instance, args, kw):
     _log_function_call(func, *args, **kw)
     return func(*args, **kw)
 
@@ -188,12 +64,13 @@ def _log_function_call(func, *args, **kw):
     if args:
         message += ' ' + ' '.join(map(str, args))
     if kw:
-        kw_str = ' '.join(['%s %r' % (k, v) for k, v in kw.iteritems()])
+        # for python2 iteritems would be better, however items() works everywhere and is reasonably well for python2
+        kw_str = ' '.join(['%s %r' % (k, v) for k, v in kw.items()])
         message += '(' + kw_str + ')'
     log.info(message)
 
 @decorator
-def dry_guard(func, *args, **kw):
+def dry_guard(func, instance, args, kw):
     _log_function_call(func, *args, **kw)
     if not options.dry:
         return func(*args, **kw)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ options = scriptine.misc.Options(
       'Programming Language :: Python',
       ],
     packages = ['scriptine'],
+    install_requires=[
+        "wrapt"
+    ],
     zip_safe = False,
     cmdclass = {
         'zipdist': zipdist,

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -5,7 +5,10 @@ from contextlib import contextmanager
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import StringIO
 
 state = set()
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -11,12 +11,12 @@ def test_guard():
     
     options.dry = True
     assert not guarded_func('hello')
-    
+
 def test_path_guard():
     
     options.dry = True
     
-    path('/tmp/foobarbaz.txt').install('hello', chmod=0644)
+    path('/tmp/foobarbaz.txt').install('hello', chmod=0o644)
     
 
 def teardown_module():

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -29,26 +29,28 @@ if sys.platform in ('cygwin', 'win32'):
 else:
     is_windows = False
 
+
 def p(**choices):
     """ Choose a value from several possible values, based on os.name """
     return choices[os.name]
+
 
 class BasicTestCase(unittest.TestCase):
     def testRelpath(self):
         root = path(p(nt='C:\\',
                       posix='/'))
         foo = root / 'foo'
-        quux =        foo / 'quux'
-        bar =         foo / 'bar'
-        boz =                bar / 'Baz' / 'Boz'
+        quux = foo / 'quux'
+        bar = foo / 'bar'
+        boz = bar / 'Baz' / 'Boz'
         up = path(os.pardir)
 
         # basics
-        self.assertEqual(root.relpathto(boz), path('foo')/'bar'/'Baz'/'Boz')
-        self.assertEqual(bar.relpathto(boz), path('Baz')/'Boz')
-        self.assertEqual(quux.relpathto(boz), up/'bar'/'Baz'/'Boz')
-        self.assertEqual(boz.relpathto(quux), up/up/up/'quux')
-        self.assertEqual(boz.relpathto(bar), up/up)
+        self.assertEqual(root.relpathto(boz), path('foo') / 'bar' / 'Baz' / 'Boz')
+        self.assertEqual(bar.relpathto(boz), path('Baz') / 'Boz')
+        self.assertEqual(quux.relpathto(boz), up / 'bar' / 'Baz' / 'Boz')
+        self.assertEqual(boz.relpathto(quux), up / up / up / 'quux')
+        self.assertEqual(boz.relpathto(bar), up / up)
 
         # x.relpathto(x) == curdir
         self.assertEqual(root.relpathto(root), os.curdir)
@@ -85,7 +87,7 @@ class BasicTestCase(unittest.TestCase):
         # Test p1/p1.
         p1 = path("foo")
         p2 = path("bar")
-        self.assertEqual(p1/p2, p(nt='foo\\bar', posix='foo/bar'))
+        self.assertEqual(p1 / p2, p(nt='foo\\bar', posix='foo/bar'))
 
     def testProperties(self):
         # Create sample path object.
@@ -123,6 +125,7 @@ class BasicTestCase(unittest.TestCase):
             self.assert_(p.uncshare == r'\\python1\share1')
             self.assert_(p.splitunc() == os.path.splitunc(str(p)))
 
+
 class TempDirTestCase(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory.
@@ -142,11 +145,11 @@ class TempDirTestCase(unittest.TestCase):
         #
         # atime isn't tested because on Windows the resolution of atime
         # is something like 24 hours.
-        
+
         sleep_time = 2.0
         if is_windows:
             sleep_time = 5.0
-        
+
         d = path(self.tempdir)
         f = d / 'test.txt'
         t0 = time.time() - sleep_time / 2
@@ -162,12 +165,12 @@ class TempDirTestCase(unittest.TestCase):
                 self.assert_(t0 <= ct <= t1)
 
             time.sleep(sleep_time)
-            fobj = file(f, 'ab')
-            fobj.write('some bytes')
+            fobj = open(f, 'ab')
+            fobj.write(b'some bytes')
             fobj.close()
 
             time.sleep(sleep_time)
-            
+
             f_new = d / 'test_new.txt'
             f_new.touch()
             self.assert_(f_new.newer(f))
@@ -197,7 +200,7 @@ class TempDirTestCase(unittest.TestCase):
     def testListing(self):
         d = path(self.tempdir)
         self.assertEqual(d.listdir(), [])
-        
+
         f = 'testfile.txt'
         af = d / f
         self.assertEqual(af, os.path.join(d, f))
@@ -221,7 +224,7 @@ class TempDirTestCase(unittest.TestCase):
         # Try a test with 20 files
         files = [d / ('%d.txt' % i) for i in range(20)]
         for f in files:
-            fobj = file(f, 'w')
+            fobj = open(f, 'w')
             fobj.write('some text\n')
             fobj.close()
         try:
@@ -245,7 +248,7 @@ class TempDirTestCase(unittest.TestCase):
         tempf.touch()
         try:
             foo = d / 'foo'
-            boz =      foo / 'bar' / 'baz' / 'boz'
+            boz = foo / 'bar' / 'baz' / 'boz'
             boz.makedirs()
             try:
                 self.assert_(boz.isdir())
@@ -254,8 +257,8 @@ class TempDirTestCase(unittest.TestCase):
             self.failIf(foo.exists())
             self.assert_(d.exists())
 
-            foo.mkdir(0750)
-            boz.makedirs(0700)
+            foo.mkdir(0o750)
+            boz.makedirs(0o700)
             try:
                 self.assert_(boz.isdir())
             finally:
@@ -307,16 +310,15 @@ class TempDirTestCase(unittest.TestCase):
         testFile.copy(testA)
         self.assert_(testCopy2.isfile())
         self.assert_(testFile.bytes() == testCopy2.bytes())
-        
+
         # Test install file
-        testFile.install(testInstall, chmod=0740)
+        testFile.install(testInstall, chmod=0o740)
         stats = stat.S_IMODE(testInstall.stat().st_mode)
-        
-        self.assert_(stats == 
-            stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP)
+
+        self.assert_(stats ==
+                     stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP)
         testInstall.unlink()
-        
-        
+
         # Make a link for the next test to use.
         if hasattr(os, 'symlink'):
             testFile.symlink(testLink)
@@ -363,25 +365,25 @@ class TempDirTestCase(unittest.TestCase):
 
     def testPatterns(self):
         d = path(self.tempdir)
-        names = [ 'x.tmp', 'x.xtmp', 'x2g', 'x22', 'x.txt' ]
-        dirs = [d, d/'xdir', d/'xdir.tmp', d/'xdir.tmp'/'xsubdir']
+        names = ['x.tmp', 'x.xtmp', 'x2g', 'x22', 'x.txt']
+        dirs = [d, d / 'xdir', d / 'xdir.tmp', d / 'xdir.tmp' / 'xsubdir']
 
         for e in dirs:
             if not e.isdir():  e.makedirs()
             for name in names:
-                (e/name).touch()
-        self.assertList(d.listdir('*.tmp'), [d/'x.tmp', d/'xdir.tmp'])
-        self.assertList(d.files('*.tmp'), [d/'x.tmp'])
-        self.assertList(d.dirs('*.tmp'), [d/'xdir.tmp'])
-        self.assertList(d.walk(), [e for e in dirs if e != d] + [e/n for e in dirs for n in names])
+                (e / name).touch()
+        self.assertList(d.listdir('*.tmp'), [d / 'x.tmp', d / 'xdir.tmp'])
+        self.assertList(d.files('*.tmp'), [d / 'x.tmp'])
+        self.assertList(d.dirs('*.tmp'), [d / 'xdir.tmp'])
+        self.assertList(d.walk(), [e for e in dirs if e != d] + [e / n for e in dirs for n in names])
         self.assertList(d.walk('*.tmp'),
-                        [e/'x.tmp' for e in dirs] + [d/'xdir.tmp'])
-        self.assertList(d.walkfiles('*.tmp'), [e/'x.tmp' for e in dirs])
-        self.assertList(d.walkdirs('*.tmp'), [d/'xdir.tmp'])
+                        [e / 'x.tmp' for e in dirs] + [d / 'xdir.tmp'])
+        self.assertList(d.walkfiles('*.tmp'), [e / 'x.tmp' for e in dirs])
+        self.assertList(d.walkdirs('*.tmp'), [d / 'xdir.tmp'])
 
     def testUnicode(self):
         d = path(self.tempdir)
-        p = d/'unicode.txt'
+        p = d / 'unicode.txt'
 
         def test(enc):
             """ Test that path works with the specified encoding,
@@ -483,7 +485,6 @@ class TempDirTestCase(unittest.TestCase):
             testLinesep(u'\r\n')
             testLinesep(u'\x0d\x85')
 
-
             # Again, but with linesep=None.
             p.write_lines(givenLines, enc, linesep=None)
             p.write_lines(givenLines, enc, linesep=None, append=True)
@@ -501,8 +502,9 @@ class TempDirTestCase(unittest.TestCase):
         test('UTF-16LE')
         test('UTF-16')
 
+
 if __name__ == '__main__':
     if __version__ != path_version:
-        print ("Version mismatch:  test_path.py version %s, path version %s" %
-               (__version__, path_version))
+        print("Version mismatch:  test_path.py version %s, path version %s" %
+              (__version__, path_version))
     unittest.main()


### PR DESCRIPTION
[ This should solve #2 ]

Dear Oliver Tonnhofer, thank you very much for your awesome little package

I adapted your code to also include python3 support. I tested your tests using pytest and got rid everything but the following error:

```python
Failure
Traceback (most recent call last):
  File "D:\Projects\scriptine\test\test_path.py", line 319, in testShutil
    stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP)
AssertionError: False is not true
```
I am not sure why this happens..

Further I tried your first example in the README and found some other errors.
I haven't tested it on python2.7 or something earlier, however all changes are compatible to the best of my knowledge.

I hope, that python3 will be soon integrated into scriptine =)
all the best,
Stephan

One last note: You build your own path object, that seems pretty awesome. You may know that there is pathlib (for python3) and pathlib2 (for python2) which do a very similar thing, however belong to the standard library since python 3.5 or something like that. They unfortunately miss your dry_run option, however still it might be fruitful to extend the new pathlib with your features at some time.